### PR TITLE
fix(config): Treat missing Playwright browsers as an error

### DIFF
--- a/Scraping_project/src/common/config_validator.py
+++ b/Scraping_project/src/common/config_validator.py
@@ -217,7 +217,7 @@ class ConfigHealthCheck:
 
                         except Exception:
                             self.issues.append(ValidationIssue(
-                                severity='warning',
+                                severity='error',
                                 category='dependency',
                                 message=f"Playwright browsers not installed for {stage_name} stage",
                                 suggestion="Run: playwright install"

--- a/Scraping_project/tests/common/test_config_validator.py
+++ b/Scraping_project/tests/common/test_config_validator.py
@@ -322,6 +322,53 @@ class TestConfigHealthCheck:
         assert 'High concurrency' in captured.out
         assert 'FAILED' in captured.out
 
+    def test_missing_playwright_browsers_is_error(self, tmp_path):
+        """Test that missing Playwright browsers are detected as an error."""
+        config_dict = {
+            'environment': 'test',
+            'stages': {
+                'discovery': {
+                    'allowed_domains': ['example.com'],
+                    'headless_browser': {
+                        'enabled': True,
+                        'engine': 'playwright',
+                        'browser_type': 'chromium'
+                    }
+                },
+                'enrichment': {
+                    'allowed_domains': ['example.com'],
+                    'nlp_enabled': False,
+                    'headless_browser': {'enabled': False}
+                }
+            },
+            'data': {
+                'raw_dir': str(tmp_path / 'raw'),
+                'processed_dir': str(tmp_path / 'processed'),
+                'cache_dir': str(tmp_path / 'cache'),
+                'logs_dir': str(tmp_path / 'logs'),
+            }
+        }
+
+        self.create_temp_config(tmp_path, config_dict)
+        original_config_dir = Config.config_dir
+        try:
+            Config.config_dir = tmp_path
+            config = Config(env='test', validate=True)
+
+            with patch('importlib.util.find_spec', return_value=True):
+                # Mock the context manager to raise an exception
+                with patch('playwright.sync_api.sync_playwright', side_effect=Exception("Browser not installed")):
+                    checker = ConfigHealthCheck(config)
+                    is_healthy, issues = checker.run_all_checks()
+
+                    # Should be unhealthy because browsers are missing
+                    assert is_healthy is False
+                    errors = [i for i in issues if i.severity == 'error']
+                    assert len(errors) >= 1
+                    assert 'Playwright browsers not installed' in errors[0].message
+        finally:
+            Config.config_dir = original_config_dir
+
 
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
The configuration health check in `config_validator.py` was incorrectly classifying missing Playwright browser dependencies as a 'warning'. This is incorrect because if Playwright is enabled, the application will crash at runtime without the required browsers.

This commit changes the severity of the `ValidationIssue` from 'warning' to 'error', ensuring that the pipeline halts if the environment is not correctly configured.

A new test case has been added to `test_config_validator.py` to specifically verify that this condition is caught as an error, preventing future regressions.

## Summary
<!-- What does this change? Why? -->

## Checklist
- [ ] Tests pass locally (`pytest -q`)
- [ ] Lint passes (`ruff check .`)
- [ ] Updated docs / comments (if behavior changed)
- [ ] Backwards compatible (or migration noted)

## Area labels (pick)
- [ ] area/stage1
- [ ] area/stage2
- [ ] area/stage3
- [ ] area/common
- [x] area/integration
- [ ] area/nlp
- [ ] area/ci
