### PR TITLE
Fix: Synchronize SchemaRegistry with dataclass versions

### DIFF
--- a/Scraping_project/src/common/schemas.py
+++ b/Scraping_project/src/common/schemas.py
@@ -134,8 +134,8 @@ class SchemaRegistry:
 
     # Current schema versions
     CURRENT_VERSIONS = {
-        "DiscoveryItem": "2.0",
-        "ValidationResult": "2.0",
+        "DiscoveryItem": "2.1",
+        "ValidationResult": "2.1",
         "EnrichmentItem": "2.0",
         "URLRecord": "1.0",
         "PipelineStats": "1.0"

--- a/Scraping_project/tests/common/test_schemas.py
+++ b/Scraping_project/tests/common/test_schemas.py
@@ -11,7 +11,16 @@ SRC_DIR = Path(__file__).resolve().parents[2] / "src"
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
-from common.schemas import DiscoveryItem, EnrichmentItem, ValidationResult  # noqa: E402
+from common.schemas import DiscoveryItem, EnrichmentItem, ValidationResult, SchemaRegistry  # noqa: E402
+
+
+def test_schema_registry_is_in_sync():
+    """
+    Tests that the SchemaRegistry is in sync with the schema versions
+    defined in the dataclasses.
+    """
+    assert SchemaRegistry.get_current_version("DiscoveryItem") == DiscoveryItem.schema_version
+    assert SchemaRegistry.get_current_version("ValidationResult") == ValidationResult.schema_version
 
 
 def test_discovery_item_creation():


### PR DESCRIPTION
The SchemaRegistry in `src/common/schemas.py` was out of sync with the schema versions defined in the `DiscoveryItem` and `ValidationResult` dataclasses. The registry listed version "2.0" for both, while the dataclasses were at version "2.1".

This change updates the `CURRENT_VERSIONS` dictionary in the `SchemaRegistry` to align with the actual schema versions, ensuring that the registry serves as a reliable single source of truth.

A new test case has been added to `tests/common/test_schemas.py` to verify this synchronization and prevent future regressions. All existing tests have been preserved and continue to pass.

## Summary
<!-- What does this change? Why? -->

## Checklist
- [ ] Tests pass locally (`pytest -q`)
- [ ] Lint passes (`ruff check .`)
- [ ] Updated docs / comments (if behavior changed)
- [ ] Backwards compatible (or migration noted)

## Area labels (pick)
- [ ] area/stage1
- [ ] area/stage2
- [ ] area/stage3
- [ ] area/common
- [ ] area/integration
- [ ] area/nlp
- [ ] area/ci
