### PR TITLE
Fix URL normalization to preserve double slashes

### DIFF
--- a/Scraping_project/src/common/urls.py
+++ b/Scraping_project/src/common/urls.py
@@ -9,8 +9,12 @@ def _sanitize_path(path: str) -> str:
     if not path:
         return ""
 
-    has_trailing = path.endswith("/")
-    candidate = path if path.startswith("/") else f"/{path}"
+    # Protect double slashes from being collapsed by normpath
+    placeholder = "___DOUBLE_SLASH___"
+    path_with_placeholder = path.replace("//", placeholder)
+
+    has_trailing = path_with_placeholder.endswith("/")
+    candidate = path_with_placeholder if path_with_placeholder.startswith("/") else f"/{path_with_placeholder}"
 
     normalized = posixpath.normpath(candidate)
     if normalized == ".":
@@ -22,7 +26,8 @@ def _sanitize_path(path: str) -> str:
     if not normalized.startswith("/"):
         normalized = f"/{normalized}"
 
-    return normalized
+    # Restore double slashes
+    return normalized.replace(placeholder, "//")
 
 
 def normalize_url(url: str) -> str:

--- a/Scraping_project/tests/common/test_urls.py
+++ b/Scraping_project/tests/common/test_urls.py
@@ -1,0 +1,16 @@
+import pytest
+
+from src.common.urls import normalize_url
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        # Existing test cases from memory
+        ("http://example.com", "http://example.com"),
+        ("https://example.com/a/b/../c", "https://example.com/a/c"),
+        ("http://example.com/a//b", "http://example.com/a//b"),
+    ],
+)
+def test_normalize_url(url, expected):
+    assert normalize_url(url) == expected


### PR DESCRIPTION
The `_sanitize_path` function in `src/common/urls.py` was using `posixpath.normpath` in a way that collapsed double slashes (`//`) in URL paths into a single slash. This can be incorrect for URLs where double slashes are intentional.

This change modifies `_sanitize_path` to use a placeholder to protect double slashes during normalization, ensuring they are preserved in the final URL.

A new test file with a failing test case was added to verify the bug and the fix.

## Summary
<!-- What does this change? Why? -->

## Checklist
- [ ] Tests pass locally (`pytest -q`)
- [ ] Lint passes (`ruff check .`)
- [ ] Updated docs / comments (if behavior changed)
- [ ] Backwards compatible (or migration noted)

## Area labels (pick)
- [ ] area/stage1
- [ ] area/stage2
- [ ] area/stage3
- [ ] area/common
- [ ] area/integration
- [ ] area/nlp
- [ ] area/ci
