### PR TITLE
Fix symlink vulnerability in temp directory cleanup

### DIFF
--- a/Scraping_project/src/orchestrator/main.py
+++ b/Scraping_project/src/orchestrator/main.py
@@ -243,16 +243,26 @@ def _cleanup_temp_directory(temp_dir: Path, max_age_hours: int = 24):
     try:
         for item in temp_dir.iterdir():
             try:
-                # Get file modification time
-                mod_time = datetime.fromtimestamp(item.stat().st_mtime)
+                # Use lstat to get info of the item itself, not its target (if it's a symlink).
+                # This is critical for security to prevent symlink attacks.
+                stat_result = item.lstat()
+                mod_time = datetime.fromtimestamp(stat_result.st_mtime)
 
                 if mod_time < cutoff_time:
-                    if item.is_file():
-                        size = item.stat().st_size
+                    # IMPORTANT: Check for symlink first to avoid traversing it.
+                    if item.is_symlink():
+                        size = stat_result.st_size
+                        item.unlink()
+                        removed_count += 1
+                        removed_size += size
+                    elif item.is_file():
+                        size = stat_result.st_size
                         item.unlink()
                         removed_count += 1
                         removed_size += size
                     elif item.is_dir():
+                        # This is now safe, as is_dir() is only called after we've
+                        # confirmed the item is not a symlink.
                         size = sum(f.stat().st_size for f in item.rglob('*') if f.is_file())
                         shutil.rmtree(item)
                         removed_count += 1

--- a/Scraping_project/tests/orchestrator/test_main.py
+++ b/Scraping_project/tests/orchestrator/test_main.py
@@ -1,12 +1,76 @@
-"""Tests for main orchestrator module.
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
 
-NOTE: These tests are outdated and need to be rewritten to match the current sync implementation.
-The main.py module was refactored to use sync functions (run_stage1_discovery_sync, main_sync)
-instead of async functions (run_stage1_discovery, run_stage2_validation, run_stage3_enrichment, main).
+# Add project root to path to allow src imports
+project_root = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(project_root))
 
-TODO: Rewrite tests to match current implementation.
-"""
+from src.orchestrator.main import _cleanup_temp_directory
 
-import pytest
 
-pytest.skip("Outdated tests - needs rewrite for sync implementation", allow_module_level=True)
+class TestCleanupTempDirectory(unittest.TestCase):
+
+    def setUp(self):
+        # Create a temporary directory for the entire test
+        self.test_dir = tempfile.mkdtemp()
+        self.temp_dir = Path(self.test_dir) / 'temp'
+        self.temp_dir.mkdir()
+
+    def tearDown(self):
+        # Clean up the test directory
+        shutil.rmtree(self.test_dir)
+
+    def test_cleanup_does_not_follow_symlink_to_delete_external_directory(self):
+        """
+        Verify that the cleanup function does not traverse symlinks and delete
+        directories outside the temp folder.
+        """
+        # 1. Arrange
+        # Create an external directory that should NOT be deleted
+        external_dir = Path(self.test_dir) / 'external_safe_dir'
+        external_dir.mkdir()
+        (external_dir / 'safe_file.txt').touch()
+
+        # Create a symlink inside the temp directory pointing to the external one
+        symlink_to_external = self.temp_dir / 'symlink_to_danger'
+
+        # Make the symlink "old" so the cleanup function tries to delete it
+        two_days_ago = (datetime.now() - timedelta(days=2)).timestamp()
+
+        # Create the symlink. Skip test if not supported.
+        try:
+            os.symlink(external_dir, symlink_to_external, target_is_directory=True)
+        except (OSError, AttributeError, NotImplementedError) as e:
+            # AttributeError for os.symlink not on old pythons/windows
+            # OSError for permissions issues
+            # NotImplementedError on some systems
+            self.skipTest(f"Symlink creation failed: {e}")
+
+        # Manually set the modification time of the symlink itself.
+        # This can fail with permission errors in some environments.
+        try:
+            os.utime(symlink_to_external, (two_days_ago, two_days_ago), follow_symlinks=False)
+        except OSError as e:
+            self.skipTest(f"Could not set modification time on symlink: {e}")
+
+
+        # 2. Act
+        # Run the cleanup function with a 24-hour max age
+        _cleanup_temp_directory(self.temp_dir, max_age_hours=24)
+
+        # 3. Assert
+        # The symlink inside the temp dir should be gone
+        self.assertFalse(symlink_to_external.exists(), "Symlink should have been deleted")
+
+        # The external directory and its contents MUST still exist
+        self.assertTrue(external_dir.exists(), "External directory was deleted, but should not have been.")
+        self.assertTrue((external_dir / 'safe_file.txt').exists(), "File in external directory was deleted.")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The `_cleanup_temp_directory` function was vulnerable to a symlink attack. It used `item.stat()`, which follows symbolic links, to check the modification time of files and directories in the temp folder. This could allow a malicious user to create a symlink to a critical system directory, causing the cleanup function to delete it.

This patch fixes the vulnerability by:
- Using `item.lstat()` to get information about the symlink itself, not its target.
- Explicitly checking for symlinks with `item.is_symlink()` and unlinking them, rather than traversing them.

A new test case has been added to verify that the fix prevents the vulnerability. The test creates a symlink in the temp directory pointing to an external directory and asserts that the external directory is not deleted by the cleanup function.

## Summary
<!-- What does this change? Why? -->

## Checklist
- [ ] Tests pass locally (`pytest -q`)
- [ ] Lint passes (`ruff check .`)
- [ ] Updated docs / comments (if behavior changed)
- [ ] Backwards compatible (or migration noted)

## Area labels (pick)
- [ ] area/stage1
- [ ] area/stage2
- [ ] area/stage3
- [ ] area/common
- [ ] area/integration
- [ ] area/nlp
- [ ] area/ci
