### PR TITLE
fix(config): Report missing Playwright browsers as errors

### DIFF
--- a/Scraping_project/src/common/config_validator.py
+++ b/Scraping_project/src/common/config_validator.py
@@ -217,7 +217,7 @@ class ConfigHealthCheck:
 
                         except Exception:
                             self.issues.append(ValidationIssue(
-                                severity='warning',
+                                severity='error',
                                 category='dependency',
                                 message=f"Playwright browsers not installed for {stage_name} stage",
                                 suggestion="Run: playwright install"

--- a/Scraping_project/tests/common/test_config_validator.py
+++ b/Scraping_project/tests/common/test_config_validator.py
@@ -373,6 +373,59 @@ class TestConfigHealthCheck:
         finally:
             Config.config_dir = original_config_dir
 
+    def test_missing_playwright_browsers_issue_details(self, tmp_path):
+        """Test the details of the issue raised for missing Playwright browsers."""
+        seed_file = tmp_path / 'seeds.csv'
+        seed_file.write_text('url\nhttps://example.com')
+
+        config_dict = {
+            'environment': 'test',
+            'stages': {
+                'discovery': {
+                    'allowed_domains': ['example.com'],
+                    'seed_file': str(seed_file),
+                    'headless_browser': {
+                        'enabled': True,
+                        'engine': 'playwright',
+                        'browser_type': 'chromium'
+                    }
+                },
+                'enrichment': {
+                    'allowed_domains': ['example.com'],
+                    'nlp_enabled': False,
+                    'headless_browser': {'enabled': False}
+                }
+            },
+            'data': {
+                'raw_dir': str(tmp_path / 'raw'),
+                'processed_dir': str(tmp_path / 'processed'),
+                'cache_dir': str(tmp_path / 'cache'),
+                'logs_dir': str(tmp_path / 'logs'),
+            }
+        }
+
+        self.create_temp_config(tmp_path, config_dict)
+        original_config_dir = Config.config_dir
+        try:
+            Config.config_dir = tmp_path
+            config = Config(env='test', validate=True)
+
+            with patch('importlib.util.find_spec', return_value=True):
+                with patch('playwright.sync_api.sync_playwright', side_effect=Exception("Browser not installed")):
+                    checker = ConfigHealthCheck(config)
+                    _, issues = checker.run_all_checks()
+
+                    playwright_errors = [
+                        i for i in issues
+                        if i.severity == 'error' and 'Playwright' in i.message
+                    ]
+                    assert len(playwright_errors) == 1
+                    issue = playwright_errors[0]
+                    assert issue.category == 'dependency'
+                    assert issue.suggestion == "Run: playwright install"
+        finally:
+            Config.config_dir = original_config_dir
+
 
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/data/config/adaptive_depth.json
+++ b/data/config/adaptive_depth.json
@@ -3,13 +3,13 @@
     "uconn.edu/valid": {
       "section_pattern": "uconn.edu/valid",
       "total_urls_discovered": 0,
-      "total_urls_validated": 7,
-      "total_content_pages": 7,
+      "total_urls_validated": 11,
+      "total_content_pages": 11,
       "avg_content_quality": 0.0,
       "avg_word_count": 0,
       "max_useful_depth": 0,
       "current_recommended_depth": 3,
-      "last_updated": "2025-10-05T02:59:52.287279",
+      "last_updated": "2025-10-05T03:55:44.299667",
       "has_valuable_content": false,
       "content_density": 0.0,
       "avg_links_per_page": 0.0
@@ -23,7 +23,7 @@
       "avg_word_count": 0,
       "max_useful_depth": 0,
       "current_recommended_depth": 3,
-      "last_updated": "2025-10-05T02:59:52.287345",
+      "last_updated": "2025-10-05T03:55:44.299732",
       "has_valuable_content": false,
       "content_density": 0.0,
       "avg_links_per_page": 0.0
@@ -31,13 +31,13 @@
     "uconn.edu/another": {
       "section_pattern": "uconn.edu/another",
       "total_urls_discovered": 0,
-      "total_urls_validated": 7,
-      "total_content_pages": 7,
+      "total_urls_validated": 11,
+      "total_content_pages": 11,
       "avg_content_quality": 0.0,
       "avg_word_count": 0,
       "max_useful_depth": 0,
       "current_recommended_depth": 3,
-      "last_updated": "2025-10-05T02:59:52.329650",
+      "last_updated": "2025-10-05T03:55:44.342323",
       "has_valuable_content": false,
       "content_density": 0.0,
       "avg_links_per_page": 0.0
@@ -46,7 +46,7 @@
   "metadata": {
     "base_depth": 3,
     "max_depth": 8,
-    "last_updated": "2025-10-05T02:59:52.331650",
+    "last_updated": "2025-10-05T03:55:44.344768",
     "total_sections": 3
   }
 }

--- a/data/feedback/stage2_feedback.json
+++ b/data/feedback/stage2_feedback.json
@@ -106,8 +106,68 @@
           "failed": 1
         }
       }
+    },
+    {
+      "session_id": "session_20251005_034000",
+      "started_at": "2025-10-05T03:40:00.060543",
+      "completed_at": "2025-10-05T03:40:00.153801",
+      "total_discovered": 0,
+      "total_validated": 2,
+      "total_failed": 1,
+      "success_rate": 0.6666666666666666,
+      "source_performance": {
+        "unknown": {
+          "validated": 2,
+          "failed": 1
+        }
+      }
+    },
+    {
+      "session_id": "session_20251005_034104",
+      "started_at": "2025-10-05T03:41:04.443053",
+      "completed_at": "2025-10-05T03:41:04.539346",
+      "total_discovered": 0,
+      "total_validated": 2,
+      "total_failed": 1,
+      "success_rate": 0.6666666666666666,
+      "source_performance": {
+        "unknown": {
+          "validated": 2,
+          "failed": 1
+        }
+      }
+    },
+    {
+      "session_id": "session_20251005_035219",
+      "started_at": "2025-10-05T03:52:19.075548",
+      "completed_at": "2025-10-05T03:52:19.166072",
+      "total_discovered": 0,
+      "total_validated": 2,
+      "total_failed": 1,
+      "success_rate": 0.6666666666666666,
+      "source_performance": {
+        "unknown": {
+          "validated": 2,
+          "failed": 1
+        }
+      }
+    },
+    {
+      "session_id": "session_20251005_035544",
+      "started_at": "2025-10-05T03:55:44.250347",
+      "completed_at": "2025-10-05T03:55:44.342650",
+      "total_discovered": 0,
+      "total_validated": 2,
+      "total_failed": 1,
+      "success_rate": 0.6666666666666666,
+      "source_performance": {
+        "unknown": {
+          "validated": 2,
+          "failed": 1
+        }
+      }
     }
   ],
-  "last_updated": "2025-10-05T02:59:52.330102",
-  "total_sessions": 7
+  "last_updated": "2025-10-05T03:55:44.342787",
+  "total_sessions": 11
 }


### PR DESCRIPTION
The configuration health check in `_check_playwright_browsers` was incorrectly reporting a missing Playwright browser as a 'warning' instead of an 'error'. This could lead to pipeline failures at runtime if Playwright is enabled without the necessary browsers installed.

This commit changes the severity of the validation issue to 'error', ensuring that the health check fails as expected in this scenario.

A new test, `test_missing_playwright_browsers_issue_details`, has been added to specifically verify that the issue is reported with the correct severity and suggestion. The existing test, `test_missing_playwright_browsers_is_error`, now passes as a result of this fix.

## Summary
<!-- What does this change? Why? -->

## Checklist
- [ ] Tests pass locally (`pytest -q`)
- [ ] Lint passes (`ruff check .`)
- [ ] Updated docs / comments (if behavior changed)
- [ ] Backwards compatible (or migration noted)

## Area labels (pick)
- [ ] area/stage1
- [ ] area/stage2
- [ ] area/stage3
- [ ] area/common
- [ ] area/integration
- [ ] area/nlp
- [ ] area/ci
