### PR TITLE
fix(cli): Ensure non-zero exit code on export failure

### DIFF
--- a/Scraping_project/cli.py
+++ b/Scraping_project/cli.py
@@ -186,15 +186,22 @@ def cmd_export(args):
     if args.table:
         logger.info(f"Exporting table: {args.table}")
         result = manager.export(args.table, args.output, format=args.format)
-        logger.info(f"✅ Exported: {result}")
+        if 'error' in result:
+            raise RuntimeError(f"Export failed for table {args.table}: {result['error']}")
+        logger.info(f"✅ Exported to {result.get('path')}")
     else:
         logger.info(f"Exporting all tables to: {args.output}")
         results = manager.export_all(args.output, format=args.format)
+        has_errors = False
         for r in results:
             if 'error' in r:
                 logger.warning(f"  ✗ {r['table']}: {r['error']}")
+                has_errors = True
             else:
                 logger.info(f"  ✓ {r['table']}: {r['rows']} rows, {r['size_mb']:.2f} MB")
+
+        if has_errors:
+            raise RuntimeError("One or more table exports failed.")
 
 
 def cmd_health(args):

--- a/Scraping_project/tests/unit/test_cli.py
+++ b/Scraping_project/tests/unit/test_cli.py
@@ -1,0 +1,47 @@
+import sys
+from unittest.mock import patch, MagicMock
+import pytest
+
+# Add project root to path to allow importing 'cli'
+sys.path.insert(0, 'Scraping_project')
+import cli
+
+def test_cli_help_exits_cleanly():
+    """Verify that `cli.py --help` exits with code 0."""
+    with patch.object(sys, 'argv', ['cli.py', '--help']):
+        with pytest.raises(SystemExit) as e:
+            cli.main()
+        assert e.value.code == 0
+
+@patch('src.common.delta_lake.get_delta_manager')
+def test_export_non_existent_table_fails(mock_get_manager):
+    """Verify `export --table non_existent` exits with 0 (the bug)."""
+    mock_manager = MagicMock()
+    mock_manager.export.return_value = {'error': 'Table does not exist'}
+    mock_get_manager.return_value = mock_manager
+
+    with patch.object(sys, 'argv', ['cli.py', 'export', '--table', 'non_existent_table']):
+        with pytest.raises(SystemExit) as e:
+            cli.main()
+        # This will fail, proving the bug, because the script exits with 0
+        assert e.value.code != 0, "BUG: The script exited with 0 for a failed single export."
+
+@patch('src.common.delta_lake.get_delta_manager')
+def test_export_all_with_failures_exits_non_zero(mock_get_manager):
+    """Verify `export` (all) exits with 0 (the bug) even if a table fails."""
+    # Configure the mock manager to simulate a failed export
+    mock_manager = MagicMock()
+    # Correctly mock the success case to prevent KeyError
+    mock_manager.export_all.return_value = [
+        {'table': 'table1', 'rows': 100, 'size_mb': 1.2},
+        {'table': 'table2', 'error': 'Mock export failed'}
+    ]
+    mock_get_manager.return_value = mock_manager
+
+    # Run the export command for all tables
+    with patch.object(sys, 'argv', ['cli.py', 'export']):
+        with pytest.raises(SystemExit) as e:
+            cli.main()
+
+    # This assertion will fail, proving the bug. The script exits with 0.
+    assert e.value.code != 0, "BUG: The script exited with 0 despite a partial export failure."


### PR DESCRIPTION
The `cli.py export` command previously exited with a success code (0) even when individual table exports failed. This could mask errors in automated scripts that rely on exit codes to determine success or failure.

This commit modifies the `cmd_export` function to check for errors during both single-table and all-table export operations. If an error is detected, a `RuntimeError` is raised. This exception is caught by the main `try...except` block, which then causes the script to exit with a non-zero status code, correctly signaling the failure.

Additionally, a new test file, `tests/unit/test_cli.py`, has been added. These tests mock export failure scenarios and assert that the CLI now exits with a non-zero status code, confirming the fix. The tests were designed to call the `main` function directly for more reliable mocking, rather than using `subprocess.run`.

## Summary
<!-- What does this change? Why? -->

## Checklist
- [ ] Tests pass locally (`pytest -q`)
- [ ] Lint passes (`ruff check .`)
- [ ] Updated docs / comments (if behavior changed)
- [ ] Backwards compatible (or migration noted)

## Area labels (pick)
- [ ] area/stage1
- [ ] area/stage2
- [ ] area/stage3
- [ ] area/common
- [ ] area/integration
- [ ] area/nlp
- [ ] area/ci
