### PR TITLE
fix(retry): Ensure backoff delay respects max_backoff with jitter

### DIFF
--- a/Scraping_project/src/common/retry_middleware.py
+++ b/Scraping_project/src/common/retry_middleware.py
@@ -167,12 +167,13 @@ class IntelligentRetryMiddleware(RetryMiddleware):
             Delay in seconds
         """
         delay = self.backoff_base ** retry_count
-        delay = min(delay, self.backoff_max)
 
         # Add small random jitter to prevent thundering herd
         import random
         jitter = random.uniform(0, 0.1 * delay)
         delay += jitter
+
+        delay = min(delay, self.backoff_max)
 
         return delay
 

--- a/Scraping_project/tests/common/test_retry_middleware.py
+++ b/Scraping_project/tests/common/test_retry_middleware.py
@@ -1,0 +1,45 @@
+import sys
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Add the project root to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+
+from scrapy.settings import Settings
+
+from src.common.retry_middleware import IntelligentRetryMiddleware
+
+
+class TestIntelligentRetryMiddleware(unittest.TestCase):
+    def setUp(self):
+        self.settings = Settings(
+            {
+                "RETRY_BACKOFF_BASE": 2,
+                "RETRY_BACKOFF_MAX": 10,
+            }
+        )
+        self.middleware = IntelligentRetryMiddleware(self.settings)
+
+    @patch("random.uniform")
+    def test_calculate_backoff_delay_exceeds_max_with_jitter(self, mock_uniform):
+        # Arrange
+        retry_count = 4  # This will produce a delay of 2^4 = 16
+        mock_uniform.return_value = (
+            5  # A large jitter to make the test case more obvious
+        )
+
+        # Act
+        delay = self.middleware._calculate_backoff_delay(retry_count)
+
+        # Assert
+        self.assertLessEqual(
+            delay,
+            self.settings.get("RETRY_BACKOFF_MAX"),
+            "The calculated delay should not exceed the maximum backoff time, even with jitter.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The `_calculate_backoff_delay` function in `IntelligentRetryMiddleware` was incorrectly applying jitter *after* capping the delay at `backoff_max`. This could cause the final delay to exceed the intended maximum backoff time.

This commit fixes the issue by applying the jitter to the uncapped delay and then capping the result, ensuring that the final delay, including jitter, never exceeds `backoff_max`. A new test case has been added to verify this behavior.

## Summary
<!-- What does this change? Why? -->

## Checklist
- [ ] Tests pass locally (`pytest -q`)
- [ ] Lint passes (`ruff check .`)
- [ ] Updated docs / comments (if behavior changed)
- [ ] Backwards compatible (or migration noted)

## Area labels (pick)
- [ ] area/stage1
- [ ] area/stage2
- [ ] area/stage3
- [ ] area/common
- [ ] area/integration
- [ ] area/nlp
- [ ] area/ci
