### PR TITLE
Refactor: Move random import to module level in retry_middleware

### DIFF
--- a/Scraping_project/src/common/retry_middleware.py
+++ b/Scraping_project/src/common/retry_middleware.py
@@ -7,6 +7,7 @@ Implements smart retry logic:
 """
 
 import logging
+import random
 import time
 
 from scrapy import Request, Spider
@@ -170,7 +171,6 @@ class IntelligentRetryMiddleware(RetryMiddleware):
         delay = min(delay, self.backoff_max)
 
         # Add small random jitter to prevent thundering herd
-        import random
         jitter = random.uniform(0, 0.1 * delay)
         delay += jitter
 

--- a/Scraping_project/tests/unit/test_retry_middleware.py
+++ b/Scraping_project/tests/unit/test_retry_middleware.py
@@ -1,0 +1,20 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from src.common.retry_middleware import IntelligentRetryMiddleware
+
+class TestIntelligentRetryMiddleware(unittest.TestCase):
+    def test_no_random_import_in_backoff_calculation(self):
+        """
+        Verify that 'import random' is not called inside _calculate_backoff_delay.
+        """
+        settings = MagicMock()
+        settings.getint.side_effect = lambda key, default=None: default if default is not None else 2
+        middleware = IntelligentRetryMiddleware(settings=settings)
+
+        with patch('builtins.__import__') as mock_import:
+            middleware._calculate_backoff_delay(1)
+            for call in mock_import.call_args_list:
+                self.assertNotEqual(call.args[0], 'random', "Found 'import random' inside _calculate_backoff_delay")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Moved the `import random` statement from the `_calculate_backoff_delay` function to the top of the file. This avoids re-importing the module on every call, improving performance and adhering to Python best practices.

Added a new unit test to verify that the `random` module is not imported within the `_calculate_backoff_delay` function.

## Summary
<!-- What does this change? Why? -->

## Checklist
- [ ] Tests pass locally (`pytest -q`)
- [ ] Lint passes (`ruff check .`)
- [ ] Updated docs / comments (if behavior changed)
- [ ] Backwards compatible (or migration noted)

## Area labels (pick)
- [ ] area/stage1
- [ ] area/stage2
- [ ] area/stage3
- [ ] area/common
- [ ] area/integration
- [ ] area/nlp
- [ ] area/ci
