### PR TITLE
fix(delta_lake): Use deltalake library for consistent exports

### DIFF
--- a/Scraping_project/src/common/delta_lake.py
+++ b/Scraping_project/src/common/delta_lake.py
@@ -255,40 +255,37 @@ class DeltaLakeManager:
 
     def export(self, table_name: str, output_path: str, format: str = 'csv'):
         """Export table to file.
-
         Args:
             table_name: Name of table to export
             output_path: Output file path
             format: Output format ('csv', 'json', 'parquet')
         """
-        try:
-            from pathlib import Path
-
-            import duckdb
-        except ImportError:
-            raise ImportError("Export requires duckdb. Install: pip install duckdb") from None
+        from pathlib import Path
+        import pandas as pd
+        import pyarrow as pa
+        from deltalake import DeltaTable
 
         table_path = self.tables.get(table_name)
         if not table_path:
             raise ValueError(f"Unknown table: {table_name}")
 
+        # Gracefully handle non-existent tables
         if not (table_path / "_delta_log").exists():
-            raise ValueError(f"No data in table: {table_name}")
+            logger.warning(f"No data in table: {table_name}, exporting empty file.")
+            # Create an empty PyArrow table to ensure downstream compatibility
+            pa_table = pa.Table.from_pylist([])
+        else:
+            # Read data using deltalake to respect the transaction log
+            table = DeltaTable(str(table_path))
+            pa_table = table.to_pyarrow_table()
 
-        parquet_files = list(table_path.glob("*.parquet"))
-        if not parquet_files:
-            raise ValueError(f"No parquet files in table: {table_name}")
-
-        con = duckdb.connect(database=':memory:')
-        query = f"SELECT * FROM read_parquet('{table_path}/*.parquet', union_by_name=True)"
-        result_df = con.execute(query).fetchdf()
-
-        if result_df.empty:
-            raise ValueError(f"Table {table_name} is empty")
+        # Convert to Pandas DataFrame for flexible export
+        result_df = pa_table.to_pandas()
 
         output_path = Path(output_path)
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
+        # Export to requested format
         if format == 'csv':
             result_df.to_csv(output_path, index=False)
         elif format == 'json':
@@ -298,7 +295,6 @@ class DeltaLakeManager:
         else:
             raise ValueError(f"Unsupported format: {format}")
 
-        con.close()
         logger.info(f"✅ Exported {table_name} to {output_path} ({format})")
 
         return {
@@ -307,7 +303,7 @@ class DeltaLakeManager:
             'format': format,
             'rows': len(result_df),
             'columns': len(result_df.columns),
-            'size_mb': output_path.stat().st_size / 1024 / 1024
+            'size_mb': output_path.stat().st_size / (1024 * 1024) if output_path.exists() else 0,
         }
 
     def export_all(self, output_dir: str, format: str = 'csv') -> list[dict[str, Any]]:

--- a/Scraping_project/tests/common/test_delta_lake.py
+++ b/Scraping_project/tests/common/test_delta_lake.py
@@ -1,0 +1,77 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+import pandas as pd
+import tempfile
+import shutil
+
+# Ensure project root is in Python path
+project_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(project_root))
+
+# Mock deltalake and pyarrow before importing DeltaLakeManager
+mock_deltalake_module = MagicMock()
+mock_pyarrow_module = MagicMock()
+sys.modules['deltalake'] = mock_deltalake_module
+sys.modules['pyarrow'] = mock_pyarrow_module
+
+from src.common.delta_lake import DeltaLakeManager
+
+class TestDeltaLakeManager(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.manager = DeltaLakeManager()
+        self.manager.base_path = Path(self.tmpdir)
+        # Update the tables dictionary to use the temp path
+        for table_name in list(self.manager.tables.keys()):
+            self.manager.tables[table_name] = self.manager.base_path / table_name
+        # Reset mocks before each test
+        mock_deltalake_module.reset_mock()
+        mock_pyarrow_module.reset_mock()
+
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_export_empty_table(self):
+        """Test that exporting an empty table creates a file."""
+        table_name = 'stage1_discovery'
+        # Do not create _delta_log to simulate non-existent table
+
+        # Configure the mock pyarrow module to return an empty DataFrame
+        mock_pyarrow_module.Table.from_pylist.return_value.to_pandas.return_value = pd.DataFrame()
+
+        output_path = Path(self.tmpdir) / "output.csv"
+        self.manager.export(table_name, str(output_path))
+
+        self.assertTrue(output_path.is_file())
+        self.assertEqual(output_path.stat().st_size, 1)
+
+    def test_export_non_empty_table(self):
+        """Test exporting a non-empty table."""
+        table_name = 'stage1_discovery'
+        table_path = self.manager.tables[table_name]
+        (table_path / "_delta_log").mkdir(parents=True, exist_ok=True)
+
+        # Configure the mock deltalake module to return a non-empty DataFrame
+        df = pd.DataFrame([{'col1': 'a', 'col2': 1}])
+        mock_table_instance = MagicMock()
+        mock_arrow_table = MagicMock()
+        mock_arrow_table.to_pandas.return_value = df
+        mock_table_instance.to_pyarrow_table.return_value = mock_arrow_table
+        mock_deltalake_module.DeltaTable.return_value = mock_table_instance
+
+        output_path = Path(self.tmpdir) / "output.csv"
+        self.manager.export(table_name, str(output_path))
+
+        self.assertTrue(output_path.is_file())
+        self.assertGreater(output_path.stat().st_size, 0)
+
+        read_df = pd.read_csv(output_path)
+        pd.testing.assert_frame_equal(read_df, df)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The export method in DeltaLakeManager was reading Parquet files directly, which bypasses the Delta Lake transaction log and can lead to inconsistent data reads.

This commit refactors the export method to use the `deltalake` library, ensuring that the transaction log is respected and that data exports are consistent with the table's state.

The method now also handles empty or non-existent tables gracefully by exporting an empty file instead of raising a ValueError.

New unit tests have been added to verify:
- Exporting a non-existent table creates an empty file.
- Exporting an existing, non-empty table produces the correct output.

## Summary
<!-- What does this change? Why? -->

## Checklist
- [ ] Tests pass locally (`pytest -q`)
- [ ] Lint passes (`ruff check .`)
- [ ] Updated docs / comments (if behavior changed)
- [ ] Backwards compatible (or migration noted)

## Area labels (pick)
- [ ] area/stage1
- [ ] area/stage2
- [ ] area/stage3
- [ ] area/common
- [ ] area/integration
- [ ] area/nlp
- [ ] area/ci
