### PR TITLE
fix(grafana): Fix dashboard provisioning race condition

### DIFF
--- a/Scraping_project/docker-compose.yml
+++ b/Scraping_project/docker-compose.yml
@@ -259,6 +259,15 @@ services:
       - ./monitoring/grafana_datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
       - ./monitoring/grafana_dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml
       - ./monitoring/dashboards:/etc/grafana/provisioning/dashboards
+    command: >
+      bash -c "
+        echo 'Waiting for dashboards to be available...'
+        while ! find /etc/grafana/provisioning/dashboards -mindepth 1 -maxdepth 1 -name '*.json' | read; do
+          sleep 1
+        done
+        echo 'Dashboards found. Starting Grafana.'
+        /run.sh
+      "
     restart: unless-stopped
     networks:
       - scraping_network


### PR DESCRIPTION
Fixes a race condition where the Grafana container would start and attempt to provision dashboards before the volume containing the dashboard files was fully mounted.

This was resolved by adding a command to the Grafana service in docker-compose.yml that waits for at least one JSON dashboard file to be present in the provisioning directory before starting Grafana. This ensures that dashboards are always available for provisioning at startup.

## Summary
<!-- What does this change? Why? -->

## Checklist
- [ ] Tests pass locally (`pytest -q`)
- [ ] Lint passes (`ruff check .`)
- [ ] Updated docs / comments (if behavior changed)
- [ ] Backwards compatible (or migration noted)

## Area labels (pick)
- [ ] area/stage1
- [ ] area/stage2
- [ ] area/stage3
- [ ] area/common
- [ ] area/integration
- [ ] area/nlp
- [ ] area/ci
