### PR TITLE
feat: Centralize retry, metric, and logging logic

### DIFF
--- a/Scraping_project/src/common/logging_utils.py
+++ b/Scraping_project/src/common/logging_utils.py
@@ -1,0 +1,33 @@
+import logging
+import sys
+
+def get_log_formatter() -> logging.Formatter:
+    """
+    Returns a standardized log formatter for consistent log output.
+    Format: [TIMESTAMP] [LEVEL] [LOGGER_NAME] MESSAGE
+    """
+    return logging.Formatter(
+        '[%(asctime)s] [%(levelname)s] [%(name)s] %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+
+def setup_logging(level: int = logging.INFO):
+    """
+    Configures the root logger to use the standard formatter.
+    This ensures that all loggers in the application will inherit
+    the same logging configuration.
+    Args:
+        level: The logging level to set for the root logger.
+    """
+    # Get the root logger
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+
+    # Remove any existing handlers to avoid duplicate logs
+    if root_logger.hasHandlers():
+        root_logger.handlers.clear()
+
+    # Add a new handler with the standard formatter
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(get_log_formatter())
+    root_logger.addHandler(handler)

--- a/Scraping_project/src/common/retry_middleware.py
+++ b/Scraping_project/src/common/retry_middleware.py
@@ -18,53 +18,76 @@ from scrapy.utils.response import response_status_message
 logger = logging.getLogger(__name__)
 
 
+# --- Centralized Retry Logic ---
+
+RETRYABLE_STATUS = {408, 429, 500, 502, 503, 504}
+"""Set of HTTP status codes that are considered transient and retryable."""
+
+PERMANENT_FAIL_STATUS = {400, 401, 403, 404, 410}
+"""Set of HTTP status codes that indicate a permanent failure and should not be retried."""
+
+
+def classify_status(status_code: int) -> str:
+    """Classify an HTTP status code into 'retry', 'fail', or 'success'.
+
+    Args:
+        status_code: The HTTP status code.
+
+    Returns:
+        'retry' if the status is in RETRYABLE_STATUS.
+        'fail' if the status is in PERMANENT_FAIL_STATUS.
+        'success' for all other codes (e.g., 2xx).
+    """
+    if status_code in RETRYABLE_STATUS:
+        return 'retry'
+    if status_code in PERMANENT_FAIL_STATUS:
+        return 'fail'
+    return 'success'
+
+
+def calculate_backoff(attempt: int, base: float = 2.0, max_delay: float = 300.0) -> float:
+    """Calculate exponential backoff delay with jitter.
+
+    Formula: min(base^attempt + jitter, max_delay)
+
+    Args:
+        attempt: The current retry attempt number (1-indexed).
+        base: The base for the exponential calculation.
+        max_delay: The maximum possible delay.
+
+    Returns:
+        The calculated delay in seconds.
+    """
+    delay = base ** attempt
+    # Add small random jitter to prevent thundering herd
+    jitter = random.uniform(0, 0.1 * delay)
+    delay += jitter
+    return min(delay, max_delay)
+
+
 class IntelligentRetryMiddleware(RetryMiddleware):
     """Enhanced retry middleware with exponential backoff."""
 
-    # Transient errors - should retry
-    TRANSIENT_STATUS_CODES = {408, 429, 500, 502, 503, 504}
-
-    # Permanent errors - do NOT retry
-    PERMANENT_STATUS_CODES = {400, 401, 403, 404, 410}
-
     def __init__(self, settings):
-        """Initialize middleware.
-
-        Args:
-            settings: Scrapy settings
-        """
+        """Initialize middleware."""
         super().__init__(settings)
-
         # Exponential backoff configuration
-        self.backoff_base = settings.getint('RETRY_BACKOFF_BASE', 2)
-        self.backoff_max = settings.getint('RETRY_BACKOFF_MAX', 300)  # 5 minutes max
-
-        # Per-domain retry tracking
-        self.domain_retry_counts = {}
-        self.domain_last_retry = {}
+        self.backoff_base = settings.getfloat('RETRY_BACKOFF_BASE', 2.0)
+        self.backoff_max = settings.getfloat('RETRY_BACKOFF_MAX', 300.0)
 
     def process_response(self, request: Request, response: Response, spider: Spider):
-        """Process response and determine if retry needed.
+        """Process response and determine if retry is needed based on status classification."""
+        status_action = classify_status(response.status)
 
-        Args:
-            request: Scrapy request
-            response: Scrapy response
-            spider: Scrapy spider
+        if status_action == 'retry':
+            logger.debug(f"Transient error {response.status} for {request.url[:80]}, retrying...")
+            return self._retry_with_backoff(request, response, spider)
 
-        Returns:
-            Response or new Request (for retry)
-        """
-        # Check if this is a permanent error
-        if response.status in self.PERMANENT_STATUS_CODES:
+        if status_action == 'fail':
             logger.info(
-                f"Permanent error {response.status} for {request.url[:80]}, "
-                f"not retrying"
+                f"Permanent error {response.status} for {request.url[:80]}, not retrying."
             )
             return response  # Don't retry
-
-        # Check if this is a transient error that should retry
-        if response.status in self.TRANSIENT_STATUS_CODES:
-            return self._retry_with_backoff(request, response, spider)
 
         # Success or other status - pass through
         return response
@@ -98,22 +121,13 @@ class IntelligentRetryMiddleware(RetryMiddleware):
         reason: any = None,
         spider: Spider = None,
     ) -> Request | None:
-        """Retry request with exponential backoff.
-
-        Args:
-            request: Request to retry
-            reason: Reason for retry (Response or exception)
-            spider: Spider instance
-
-        Returns:
-            New Request with backoff delay or None if max retries exceeded
-        """
+        """Retry request with exponential backoff."""
         retries = request.meta.get('retry_times', 0) + 1
         max_retry_times = self.max_retry_times
 
         if retries <= max_retry_times:
-            # Calculate exponential backoff delay
-            delay = self._calculate_backoff_delay(retries)
+            # Calculate exponential backoff delay using the centralized function
+            delay = calculate_backoff(retries, self.backoff_base, self.backoff_max)
 
             # Extract reason message
             if isinstance(reason, Response):
@@ -153,27 +167,6 @@ class IntelligentRetryMiddleware(RetryMiddleware):
                 f"Max retries ({max_retry_times}) exceeded for {request.url[:80]}"
             )
             return None
-
-    def _calculate_backoff_delay(self, retry_count: int) -> float:
-        """Calculate exponential backoff delay.
-
-        Formula: min(backoff_base^retry_count, backoff_max)
-
-        Args:
-            retry_count: Current retry attempt (1-indexed)
-
-        Returns:
-            Delay in seconds
-        """
-        delay = self.backoff_base ** retry_count
-
-        # Add small random jitter to prevent thundering herd
-        jitter = random.uniform(0, 0.1 * delay)
-        delay += jitter
-
-        delay = min(delay, self.backoff_max)
-
-        return delay
 
 
 class RateLimitMiddleware:

--- a/Scraping_project/src/scrapy_prometheus.py
+++ b/Scraping_project/src/scrapy_prometheus.py
@@ -40,113 +40,124 @@ from scrapy.http import Request, Response
 logger = logging.getLogger(__name__)
 
 
+def format_metric(name: str, prefix: str = "scrapy") -> str:
+    """Formats a metric name with a standard prefix.
+    Args:
+        name: The base name of the metric.
+        prefix: The prefix to use (defaults to 'scrapy').
+    Returns:
+        The formatted metric name.
+    """
+    return f"{prefix}_{name}"
+
+
 # Define Prometheus metrics only if available
 if PROMETHEUS_AVAILABLE:
     ITEMS_SCRAPED = Counter(
-        'scrapy_items_scraped_total',
+        format_metric('items_scraped_total'),
         'Total number of items scraped',
         ['spider']
     )
 
     ITEMS_DROPPED = Counter(
-        'scrapy_items_dropped_total',
+        format_metric('items_dropped_total'),
         'Total number of items dropped',
         ['spider']
     )
 
     REQUESTS_TOTAL = Counter(
-        'scrapy_requests_total',
+        format_metric('requests_total'),
         'Total number of requests made',
         ['spider', 'method']
     )
 
     RESPONSES_TOTAL = Counter(
-        'scrapy_responses_total',
+        format_metric('responses_total'),
         'Total number of responses received',
         ['spider', 'status_code']
     )
 
     RESPONSE_TIME = Histogram(
-        'scrapy_response_time_seconds',
+        format_metric('response_time_seconds'),
         'Response time in seconds',
         ['spider'],
         buckets=(0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, float('inf'))
     )
 
     SPIDER_OPENED = Gauge(
-        'scrapy_spider_opened',
+        format_metric('spider_opened'),
         'Number of spiders currently running',
         ['spider']
     )
 
     SPIDER_CLOSED = Counter(
-        'scrapy_spider_closed_total',
+        format_metric('spider_closed_total'),
         'Total number of spiders closed',
         ['spider', 'reason']
     )
 
     SPIDER_ERRORS = Counter(
-        'scrapy_spider_errors_total',
+        format_metric('spider_errors_total'),
         'Total number of spider errors',
         ['spider', 'exception_type']
     )
 
     REQUESTS_DROPPED = Counter(
-        'scrapy_requests_dropped_total',
+        format_metric('requests_dropped_total'),
         'Total number of requests dropped',
         ['spider', 'reason']
     )
 
     DOWNLOADER_REQUEST_BYTES = Counter(
-        'scrapy_downloader_request_bytes_total',
+        format_metric('downloader_request_bytes_total'),
         'Total bytes sent in requests',
         ['spider']
     )
 
     DOWNLOADER_RESPONSE_BYTES = Counter(
-        'scrapy_downloader_response_bytes_total',
+        format_metric('downloader_response_bytes_total'),
         'Total bytes received in responses',
         ['spider']
     )
 
     CRAWL_DURATION = Gauge(
-        'scrapy_crawl_duration_seconds',
+        format_metric('crawl_duration_seconds'),
         'Duration of the current crawl in seconds',
         ['spider']
     )
 
     URLS_SKIPPED = Counter(
-        'scrapy_urls_skipped_total',
+        format_metric('urls_skipped_total'),
         'Total number of URLs skipped by type',
         ['spider', 'skip_reason']
     )
 
     NEW_URLS_FOUND_PER_MINUTE = Gauge(
-        'scrapy_new_urls_found_per_minute',
+        format_metric('new_urls_found_per_minute'),
         'Rate of new URLs discovered per minute',
         ['spider']
     )
 
     AVERAGE_FILE_SIZE_BYTES = Gauge(
-        'scrapy_average_file_size_bytes',
+        format_metric('average_file_size_bytes'),
         'Average file size of downloaded responses',
         ['spider']
     )
 
     OFFSITE_LINKS_FOUND = Counter(
-        'scrapy_offsite_links_found_total',
+        format_metric('offsite_links_found_total'),
         'Total number of offsite/external links discovered',
         ['spider']
     )
 
     OFFSITE_CANDIDATES_SAVED = Counter(
-        'scrapy_offsite_candidates_saved_total',
+        format_metric('offsite_candidates_saved_total'),
         'Total number of offsite candidates saved to Delta Lake',
         ['spider']
     )
 
     CRAWLER_CONTENT_SUMMARY = Gauge(
-        'scrapy_crawler_content_summary',
+        format_metric('crawler_content_summary'),
         'Sample summary of scraped content for qualitative monitoring',
         ['spider']
     )

--- a/Scraping_project/src/stage2/stage2_worker.py
+++ b/Scraping_project/src/stage2/stage2_worker.py
@@ -415,4 +415,6 @@ async def run_stage2_worker():
 
 
 if __name__ == '__main__':
+    from src.common.logging_utils import setup_logging
+    setup_logging()
     asyncio.run(run_stage2_worker())

--- a/Scraping_project/src/stage3/stage3_worker.py
+++ b/Scraping_project/src/stage3/stage3_worker.py
@@ -238,4 +238,6 @@ async def run_stage3_worker():
 
 
 if __name__ == '__main__':
+    from src.common.logging_utils import setup_logging
+    setup_logging()
     asyncio.run(run_stage3_worker())

--- a/Scraping_project/tests/common/test_utils.py
+++ b/Scraping_project/tests/common/test_utils.py
@@ -1,0 +1,45 @@
+import logging
+import pytest
+from src.common.retry_middleware import classify_status, calculate_backoff
+from src.scrapy_prometheus import format_metric
+from src.common.logging_utils import get_log_formatter
+
+def test_classify_status():
+    """Tests the classify_status function."""
+    assert classify_status(200) == 'success'
+    assert classify_status(404) == 'fail'
+    assert classify_status(503) == 'retry'
+    assert classify_status(302) == 'success'
+
+def test_calculate_backoff():
+    """Tests the calculate_backoff function."""
+    # Test with default values
+    assert 2.0 <= calculate_backoff(1) <= 2.2
+    assert 4.0 <= calculate_backoff(2) <= 4.4
+    # Test with custom values
+    assert 9.0 <= calculate_backoff(2, base=3.0) <= 9.9
+    # Test max_delay
+    assert calculate_backoff(10, max_delay=100.0) == 100.0
+
+def test_format_metric():
+    """Tests the format_metric function."""
+    assert format_metric('test_metric') == 'scrapy_test_metric'
+    assert format_metric('test_metric', prefix='custom') == 'custom_test_metric'
+
+def test_get_log_formatter():
+    """Tests the get_log_formatter function."""
+    formatter = get_log_formatter()
+    assert isinstance(formatter, logging.Formatter)
+    # Create a log record and format it to check the output
+    record = logging.LogRecord(
+        name='test_logger',
+        level=logging.INFO,
+        pathname='/path/to/file.py',
+        lineno=10,
+        msg='Test message',
+        args=(),
+        exc_info=None
+    )
+    # The exact timestamp will vary, so we check the other parts of the message
+    formatted_message = formatter.format(record)
+    assert '[INFO] [test_logger] Test message' in formatted_message


### PR DESCRIPTION
This commit introduces a centralized approach to handling retries, metric name formatting, and logging across the application.

- **Retry Logic:** A `classify_status` function and a `calculate_backoff` function have been added to `src/common/retry_middleware.py` to provide a consistent retry policy. The `IntelligentRetryMiddleware` has been refactored to use this new logic.

- **Metric Formatting:** A `format_metric` function has been added to `src/scrapy_prometheus.py` to ensure all Prometheus metrics follow a consistent naming scheme.

- **Logging:** A new `src/common/logging_utils.py` module has been created to provide a shared log formatter. The stage 2 and 3 workers have been updated to use this new utility, unifying the log output format.

- **Testing:** Unit tests have been added for all new centralized functions to ensure their correctness and prevent regressions.

## Summary
<!-- What does this change? Why? -->

## Checklist
- [ ] Tests pass locally (`pytest -q`)
- [ ] Lint passes (`ruff check .`)
- [ ] Updated docs / comments (if behavior changed)
- [ ] Backwards compatible (or migration noted)

## Area labels (pick)
- [ ] area/stage1
- [ ] area/stage2
- [ ] area/stage3
- [ ] area/common
- [ ] area/integration
- [ ] area/nlp
- [ ] area/ci
