### PR TITLE
feat(spider): create a single normalize_url helper

### DIFF
--- a/Scraping_project/src/stage1/base_spider.py
+++ b/Scraping_project/src/stage1/base_spider.py
@@ -7,7 +7,7 @@ import time
 from collections import deque
 from collections.abc import Iterator
 from datetime import datetime
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, parse_qs, urlencode, urlparse
 
 import redis
 import scrapy
@@ -156,6 +156,51 @@ class BaseSpider(scrapy.Spider):
         """Return the full SHA256 hash of a URL for deduplication."""
         return hashlib.sha256(url.encode('utf-8')).hexdigest()
 
+    @staticmethod
+    def normalize_url(url: str) -> str:
+        """Normalize a URL for consistency.
+
+        - Lowercase scheme and hostname
+        - Remove fragment
+        - Remove common tracking parameters
+        """
+        try:
+            parsed = urlparse(url)
+
+            # Reconstruct query string without tracking parameters
+            query_params = parse_qs(parsed.query)
+
+            # List of trackers to remove (case-insensitive)
+            trackers_to_remove = [
+                'utm_source', 'utm_medium', 'utm_campaign',
+                'utm_term', 'utm_content', 'gclid', 'fbclid'
+            ]
+
+            # Filter out tracking parameters
+            filtered_params = {
+                k: v for k, v in query_params.items()
+                if k.lower() not in trackers_to_remove
+            }
+
+            # Rebuild the URL
+            new_query = urlencode(filtered_params, doseq=True)
+
+            # Create a new ParseResult tuple
+            normalized = ParseResult(
+                scheme=parsed.scheme.lower(),
+                netloc=parsed.netloc.lower(),
+                path=parsed.path,
+                params=parsed.params,
+                query=new_query,
+                fragment=""  # Remove fragment
+            )
+
+            return normalized.geturl()
+
+        except Exception:
+            # If parsing fails, return the original URL
+            return url
+
     def _load_seed_urls(self):
         """Return new seed URLs from Delta Lake that are not already in Redis."""
         try:
@@ -302,7 +347,8 @@ class BaseSpider(scrapy.Spider):
             base_url=response.url,
             allowed_domains=self.allowed_domains
         )
-        return list(extractor.discover_all_urls(response))
+        discovered_urls = extractor.discover_all_urls(response)
+        return [self.normalize_url(url) for url in discovered_urls]
 
     def _process_discovered_urls(self, response: Response, discovered_urls: list[str], depth: int) -> Iterator:
         """Deduplicate discovered URLs, track skips, and queue new crawl requests."""

--- a/Scraping_project/src/stage1/js_spider.py
+++ b/Scraping_project/src/stage1/js_spider.py
@@ -11,6 +11,7 @@ from scrapy.http import Response
 
 from src.common.config import load_config
 from src.common.delta_lake import get_delta_manager
+from src.stage1.base_spider import BaseSpider
 from src.common.spider_config import get_spider_settings
 
 logger = logging.getLogger(__name__)
@@ -217,7 +218,7 @@ class JavaScriptSpider(scrapy.Spider):
             if absolute_url.startswith('http'):
                 urls.append(absolute_url)
 
-        return urls
+        return [BaseSpider.normalize_url(url) for url in urls]
 
     def _hash_url(self, url: str) -> str:
         """Hash URL using SHA256 for consistency with base_spider."""

--- a/Scraping_project/tests/unit/stage1/test_normalize_url.py
+++ b/Scraping_project/tests/unit/stage1/test_normalize_url.py
@@ -1,0 +1,47 @@
+"""Unit tests for the centralized URL normalization function."""
+
+import unittest
+
+from src.stage1.base_spider import BaseSpider
+
+
+class TestURLNormalization(unittest.TestCase):
+    """Test suite for URL normalization."""
+
+    def test_normalization_logic(self):
+        """Verify that various forms of messy URLs are cleaned as expected."""
+        test_cases = {
+            # Basic fragment removal
+            "https://www.uconn.edu/index.html#section1": "https://www.uconn.edu/index.html",
+
+            # Case normalization
+            "HTTPS://WWW.UCONN.EDU/": "https://www.uconn.edu/",
+
+            # Tracking parameter removal
+            "https://www.uconn.edu/?utm_source=test&variable=1": "https://www.uconn.edu/?variable=1",
+
+            # Multiple tracking parameters
+            "https://www.uconn.edu/?utm_source=test&utm_medium=cpc&variable=1": "https://www.uconn.edu/?variable=1",
+
+            # Fragment and tracker
+            "https://www.uconn.edu/page?utm_source=x#abc": "https://www.uconn.edu/page",
+
+            # No changes needed
+            "https://www.uconn.edu/clean/path": "https://www.uconn.edu/clean/path",
+
+            # External URL with trackers
+            "https://www.external.com/page?utm_campaign=spring&id=123": "https://www.external.com/page?id=123",
+
+            # Empty query after stripping
+            "https://www.uconn.edu/path?utm_source=news": "https://www.uconn.edu/path",
+
+            # Malformed URL (should pass through)
+            "htp:/invalid-url": "htp:/invalid-url"
+        }
+
+        for messy, expected in test_cases.items():
+            with self.subTest(messy=messy):
+                self.assertEqual(BaseSpider.normalize_url(messy), expected)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This commit centralizes the URL normalization logic into a single static method in the `BaseSpider` class.

The new `normalize_url` function handles:
- Lowercasing the scheme and hostname.
- Removing URL fragments.
- Stripping common tracking parameters (e.g., utm_*, gclid, fbclid).

The `ScoutSpider` and `JavaScriptSpider` have been updated to use this new helper, ensuring consistent URL normalization across the project and reducing code duplication.

A comprehensive test suite has been added to verify the normalization logic with various messy URLs.

## Summary
<!-- What does this change? Why? -->

## Checklist
- [ ] Tests pass locally (`pytest -q`)
- [ ] Lint passes (`ruff check .`)
- [ ] Updated docs / comments (if behavior changed)
- [ ] Backwards compatible (or migration noted)

## Area labels (pick)
- [ ] area/stage1
- [ ] area/stage2
- [ ] area/stage3
- [ ] area/common
- [ ] area/integration
- [ ] area/nlp
- [ ] area/ci
