### PR TITLE
refactor(retry): unify status classifier and backoff logic

### DIFF
--- a/Scraping_project/src/common/retry_middleware.py
+++ b/Scraping_project/src/common/retry_middleware.py
@@ -43,6 +43,21 @@ class IntelligentRetryMiddleware(RetryMiddleware):
         self.domain_retry_counts = {}
         self.domain_last_retry = {}
 
+    def _classify_status(self, status: int) -> str:
+        """Classify HTTP status code.
+
+        Args:
+            status: HTTP status code
+
+        Returns:
+            'retry', 'fail', or 'pass'
+        """
+        if status in self.TRANSIENT_STATUS_CODES:
+            return 'retry'
+        if status in self.PERMANENT_STATUS_CODES:
+            return 'fail'
+        return 'pass'
+
     def process_response(self, request: Request, response: Response, spider: Spider):
         """Process response and determine if retry needed.
 
@@ -54,19 +69,18 @@ class IntelligentRetryMiddleware(RetryMiddleware):
         Returns:
             Response or new Request (for retry)
         """
-        # Check if this is a permanent error
-        if response.status in self.PERMANENT_STATUS_CODES:
+        action = self._classify_status(response.status)
+
+        if action == 'retry':
+            return self._retry_with_backoff(request, response, spider)
+
+        if action == 'fail':
             logger.info(
                 f"Permanent error {response.status} for {request.url[:80]}, "
                 f"not retrying"
             )
-            return response  # Don't retry
+            return response
 
-        # Check if this is a transient error that should retry
-        if response.status in self.TRANSIENT_STATUS_CODES:
-            return self._retry_with_backoff(request, response, spider)
-
-        # Success or other status - pass through
         return response
 
     def process_exception(self, request: Request, exception: Exception, spider: Spider):
@@ -113,7 +127,7 @@ class IntelligentRetryMiddleware(RetryMiddleware):
 
         if retries <= max_retry_times:
             # Calculate exponential backoff delay
-            delay = self._calculate_backoff_delay(retries)
+            delay = self._compute_backoff(retries)
 
             # Extract reason message
             if isinstance(reason, Response):
@@ -154,7 +168,7 @@ class IntelligentRetryMiddleware(RetryMiddleware):
             )
             return None
 
-    def _calculate_backoff_delay(self, retry_count: int) -> float:
+    def _compute_backoff(self, retry_count: int) -> float:
         """Calculate exponential backoff delay.
 
         Formula: min(backoff_base^retry_count, backoff_max)

--- a/Scraping_project/tests/retry/test_classifier_and_backoff.py
+++ b/Scraping_project/tests/retry/test_classifier_and_backoff.py
@@ -1,0 +1,81 @@
+"""Tests for the retry classifier and backoff logic."""
+
+import unittest
+from scrapy.settings import Settings
+
+from src.common.retry_middleware import IntelligentRetryMiddleware
+
+
+class TestClassifierAndBackoff(unittest.TestCase):
+    """Test cases for retry classifier and backoff logic."""
+
+    def setUp(self):
+        """Set up the test case."""
+        self.settings = Settings({
+            'RETRY_BACKOFF_BASE': 2,
+            'RETRY_BACKOFF_MAX': 300,
+        })
+        self.middleware = IntelligentRetryMiddleware(self.settings)
+
+    def test_status_classification_snapshot(self):
+        """
+        Snapshot test to verify the classification of various HTTP status codes.
+        This test captures the current baseline behavior.
+        """
+        # Statuses to test and their expected classification (retry or fail)
+        status_tests = {
+            # Transient/Retryable statuses
+            408: 'retry',
+            429: 'retry',
+            500: 'retry',
+            502: 'retry',
+            503: 'retry',
+            504: 'retry',
+
+            # Permanent/Non-retryable statuses
+            400: 'fail',
+            401: 'fail',
+            403: 'fail',
+            404: 'fail',
+            410: 'fail',
+
+            # Success status
+            200: 'pass',
+        }
+
+        for status, expected_action in status_tests.items():
+            with self.subTest(status=status, expected_action=expected_action):
+                action = self.middleware._classify_status(status)
+                self.assertEqual(action, expected_action)
+
+    def test_backoff_schedule_snapshot(self):
+        """
+        Snapshot test for the backoff delay calculation.
+        Verifies the exponential backoff schedule with jitter.
+        """
+        retry_attempts = 10
+        backoff_base = self.settings.getint('RETRY_BACKOFF_BASE')
+        backoff_max = self.settings.getint('RETRY_BACKOFF_MAX')
+
+        for i in range(1, retry_attempts + 1):
+            with self.subTest(attempt=i):
+                delay = self.middleware._compute_backoff(i)
+
+                # Base delay without jitter
+                expected_base_delay = backoff_base ** i
+                # Max delay with jitter (10%)
+                expected_max_jitter_delay = expected_base_delay * 1.1
+
+                # The final delay should be capped by backoff_max
+                final_expected_max = min(expected_max_jitter_delay, backoff_max)
+                # The minimum delay can't be higher than max
+                final_expected_min = min(expected_base_delay, backoff_max)
+
+                # Assert that the delay is within the expected range (base <= delay < base * 1.1)
+                self.assertGreaterEqual(delay, final_expected_min)
+                # Allow for a tiny floating point tolerance
+                self.assertLessEqual(delay, final_expected_max + 0.0001)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Refactored the `IntelligentRetryMiddleware` to centralize the classification of retryable statuses and the calculation of backoff delays.

- Introduced a `_classify_status` method to determine whether a status code should be retried, failed, or passed.
- Renamed `_calculate_backoff_delay` to `_compute_backoff` for consistency.
- Updated the `process_response` method to use the new unified logic.
- Added snapshot tests to lock in the current behavior and prevent regressions.

## Summary
<!-- What does this change? Why? -->

## Checklist
- [ ] Tests pass locally (`pytest -q`)
- [ ] Lint passes (`ruff check .`)
- [ ] Updated docs / comments (if behavior changed)
- [ ] Backwards compatible (or migration noted)

## Area labels (pick)
- [ ] area/stage1
- [ ] area/stage2
- [ ] area/stage3
- [ ] area/common
- [ ] area/integration
- [ ] area/nlp
- [ ] area/ci
