### PR TITLE
Fix Kafka consumer group label inconsistency

### DIFF
--- a/Scraping_project/monitoring/dashboards/unified_dashboard.json.backup
+++ b/Scraping_project/monitoring/dashboards/unified_dashboard.json.backup
@@ -1,0 +1,723 @@
+{
+  "title": "Unified Dashboard",
+  "panels": [
+    {
+      "id": 1,
+      "title": "Kafka Consumer Lag",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "targets": [
+        {
+          "expr": "kafka_consumer_records_lag",
+          "legendFormat": "{{client_id}}-{{topic}}-p{{partition}}"
+        }
+      ],
+      "description": "Consumer lag in records for Kafka consumers (correct metric: kafka_consumer_records_lag)"
+    },
+    {
+      "id": 2,
+      "title": "Off-site Links Found Rate",
+      "description": "Rate of external/offsite links discovered per second",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_offsite_links_found_total[5m])",
+          "legendFormat": "{{spider}} - Offsite Links/sec",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ]
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Total Off-site Candidates",
+      "description": "Total number of offsite URLs saved to Delta Lake",
+      "type": "stat",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 8
+      },
+      "targets": [
+        {
+          "expr": "scrapy_offsite_candidates_saved_total",
+          "legendFormat": "Saved",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "blue"
+              },
+              {
+                "value": 100,
+                "color": "green"
+              },
+              {
+                "value": 1000,
+                "color": "yellow"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Scraping Speed Comparison",
+      "description": "Comparison of onsite crawling speed vs offsite link discovery",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 8
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_items_scraped_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Onsite Pages Scraped/sec",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(scrapy_offsite_links_found_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Offsite Links Found/sec",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Off-site Links Found Rate",
+      "description": "Rate of external/offsite links discovered per second",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_offsite_links_found_total[5m])",
+          "legendFormat": "{{spider}} - Offsite Links/sec",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ]
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Total Off-site Candidates",
+      "description": "Total number of offsite URLs saved to Delta Lake",
+      "type": "stat",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 16
+      },
+      "targets": [
+        {
+          "expr": "scrapy_offsite_candidates_saved_total",
+          "legendFormat": "Saved",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "blue"
+              },
+              {
+                "value": 100,
+                "color": "green"
+              },
+              {
+                "value": 1000,
+                "color": "yellow"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Scraping Speed Comparison",
+      "description": "Comparison of onsite crawling speed vs offsite link discovery",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 16
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_items_scraped_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Onsite Pages Scraped/sec",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(scrapy_offsite_links_found_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Offsite Links Found/sec",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 8,
+      "title": "Off-site Links Found Rate",
+      "description": "Rate of external/offsite links discovered per second",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_offsite_links_found_total[5m])",
+          "legendFormat": "{{spider}} - Offsite Links/sec",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ]
+        }
+      }
+    },
+    {
+      "id": 9,
+      "title": "Total Off-site Candidates",
+      "description": "Total number of offsite URLs saved to Delta Lake",
+      "type": "stat",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 24
+      },
+      "targets": [
+        {
+          "expr": "scrapy_offsite_candidates_saved_total",
+          "legendFormat": "Saved",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "blue"
+              },
+              {
+                "value": 100,
+                "color": "green"
+              },
+              {
+                "value": 1000,
+                "color": "yellow"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 10,
+      "title": "Scraping Speed Comparison",
+      "description": "Comparison of onsite crawling speed vs offsite link discovery",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 24
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_items_scraped_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Onsite Pages Scraped/sec",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(scrapy_offsite_links_found_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Offsite Links Found/sec",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 11,
+      "title": "Off-site Links Found Rate",
+      "description": "Rate of external/offsite links discovered per second",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_offsite_links_found_total[5m])",
+          "legendFormat": "{{spider}} - Offsite Links/sec",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ]
+        }
+      }
+    },
+    {
+      "id": 12,
+      "title": "Total Off-site Candidates",
+      "description": "Total number of offsite URLs saved to Delta Lake",
+      "type": "stat",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 32
+      },
+      "targets": [
+        {
+          "expr": "scrapy_offsite_candidates_saved_total",
+          "legendFormat": "Saved",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "blue"
+              },
+              {
+                "value": 100,
+                "color": "green"
+              },
+              {
+                "value": 1000,
+                "color": "yellow"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 13,
+      "title": "Scraping Speed Comparison",
+      "description": "Comparison of onsite crawling speed vs offsite link discovery",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 32
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_items_scraped_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Onsite Pages Scraped/sec",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(scrapy_offsite_links_found_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Offsite Links Found/sec",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 14,
+      "title": "Off-site Links Found Rate",
+      "description": "Rate of external/offsite links discovered per second",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_offsite_links_found_total[5m])",
+          "legendFormat": "{{spider}} - Offsite Links/sec",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ]
+        }
+      }
+    },
+    {
+      "id": 15,
+      "title": "Total Off-site Candidates",
+      "description": "Total number of offsite URLs saved to Delta Lake",
+      "type": "stat",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 40
+      },
+      "targets": [
+        {
+          "expr": "scrapy_offsite_candidates_saved_total",
+          "legendFormat": "Saved",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "blue"
+              },
+              {
+                "value": 100,
+                "color": "green"
+              },
+              {
+                "value": 1000,
+                "color": "yellow"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 16,
+      "title": "Scraping Speed Comparison",
+      "description": "Comparison of onsite crawling speed vs offsite link discovery",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 40
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_items_scraped_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Onsite Pages Scraped/sec",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(scrapy_offsite_links_found_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Offsite Links Found/sec",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    }
+  ],
+  "version": 6
+}

--- a/Scraping_project/monitoring/dashboards/unified_dashboard.json.json.backup.backup
+++ b/Scraping_project/monitoring/dashboards/unified_dashboard.json.json.backup.backup
@@ -1,0 +1,723 @@
+{
+  "title": "Unified Dashboard",
+  "panels": [
+    {
+      "id": 1,
+      "title": "Kafka Consumer Lag",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "targets": [
+        {
+          "expr": "kafka_consumer_records_lag",
+          "legendFormat": "{{client_id}}-{{topic}}-p{{partition}}"
+        }
+      ],
+      "description": "Consumer lag in records for Kafka consumers (correct metric: kafka_consumer_records_lag)"
+    },
+    {
+      "id": 2,
+      "title": "Off-site Links Found Rate",
+      "description": "Rate of external/offsite links discovered per second",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_offsite_links_found_total[5m])",
+          "legendFormat": "{{spider}} - Offsite Links/sec",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ]
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Total Off-site Candidates",
+      "description": "Total number of offsite URLs saved to Delta Lake",
+      "type": "stat",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 8
+      },
+      "targets": [
+        {
+          "expr": "scrapy_offsite_candidates_saved_total",
+          "legendFormat": "Saved",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "blue"
+              },
+              {
+                "value": 100,
+                "color": "green"
+              },
+              {
+                "value": 1000,
+                "color": "yellow"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Scraping Speed Comparison",
+      "description": "Comparison of onsite crawling speed vs offsite link discovery",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 8
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_items_scraped_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Onsite Pages Scraped/sec",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(scrapy_offsite_links_found_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Offsite Links Found/sec",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Off-site Links Found Rate",
+      "description": "Rate of external/offsite links discovered per second",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_offsite_links_found_total[5m])",
+          "legendFormat": "{{spider}} - Offsite Links/sec",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ]
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Total Off-site Candidates",
+      "description": "Total number of offsite URLs saved to Delta Lake",
+      "type": "stat",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 16
+      },
+      "targets": [
+        {
+          "expr": "scrapy_offsite_candidates_saved_total",
+          "legendFormat": "Saved",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "blue"
+              },
+              {
+                "value": 100,
+                "color": "green"
+              },
+              {
+                "value": 1000,
+                "color": "yellow"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Scraping Speed Comparison",
+      "description": "Comparison of onsite crawling speed vs offsite link discovery",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 16
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_items_scraped_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Onsite Pages Scraped/sec",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(scrapy_offsite_links_found_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Offsite Links Found/sec",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 8,
+      "title": "Off-site Links Found Rate",
+      "description": "Rate of external/offsite links discovered per second",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_offsite_links_found_total[5m])",
+          "legendFormat": "{{spider}} - Offsite Links/sec",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ]
+        }
+      }
+    },
+    {
+      "id": 9,
+      "title": "Total Off-site Candidates",
+      "description": "Total number of offsite URLs saved to Delta Lake",
+      "type": "stat",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 24
+      },
+      "targets": [
+        {
+          "expr": "scrapy_offsite_candidates_saved_total",
+          "legendFormat": "Saved",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "blue"
+              },
+              {
+                "value": 100,
+                "color": "green"
+              },
+              {
+                "value": 1000,
+                "color": "yellow"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 10,
+      "title": "Scraping Speed Comparison",
+      "description": "Comparison of onsite crawling speed vs offsite link discovery",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 24
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_items_scraped_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Onsite Pages Scraped/sec",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(scrapy_offsite_links_found_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Offsite Links Found/sec",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 11,
+      "title": "Off-site Links Found Rate",
+      "description": "Rate of external/offsite links discovered per second",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_offsite_links_found_total[5m])",
+          "legendFormat": "{{spider}} - Offsite Links/sec",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ]
+        }
+      }
+    },
+    {
+      "id": 12,
+      "title": "Total Off-site Candidates",
+      "description": "Total number of offsite URLs saved to Delta Lake",
+      "type": "stat",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 32
+      },
+      "targets": [
+        {
+          "expr": "scrapy_offsite_candidates_saved_total",
+          "legendFormat": "Saved",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "blue"
+              },
+              {
+                "value": 100,
+                "color": "green"
+              },
+              {
+                "value": 1000,
+                "color": "yellow"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 13,
+      "title": "Scraping Speed Comparison",
+      "description": "Comparison of onsite crawling speed vs offsite link discovery",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 32
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_items_scraped_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Onsite Pages Scraped/sec",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(scrapy_offsite_links_found_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Offsite Links Found/sec",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    },
+    {
+      "id": 14,
+      "title": "Off-site Links Found Rate",
+      "description": "Rate of external/offsite links discovered per second",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_offsite_links_found_total[5m])",
+          "legendFormat": "{{spider}} - Offsite Links/sec",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ]
+        }
+      }
+    },
+    {
+      "id": 15,
+      "title": "Total Off-site Candidates",
+      "description": "Total number of offsite URLs saved to Delta Lake",
+      "type": "stat",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 40
+      },
+      "targets": [
+        {
+          "expr": "scrapy_offsite_candidates_saved_total",
+          "legendFormat": "Saved",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "blue"
+              },
+              {
+                "value": 100,
+                "color": "green"
+              },
+              {
+                "value": 1000,
+                "color": "yellow"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 16,
+      "title": "Scraping Speed Comparison",
+      "description": "Comparison of onsite crawling speed vs offsite link discovery",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 40
+      },
+      "targets": [
+        {
+          "expr": "rate(scrapy_items_scraped_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Onsite Pages Scraped/sec",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(scrapy_offsite_links_found_total{spider=\"scout\"}[5m])",
+          "legendFormat": "Offsite Links Found/sec",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      }
+    }
+  ],
+  "version": 6
+}

--- a/Scraping_project/scripts/update_dashboard.py
+++ b/Scraping_project/scripts/update_dashboard.py
@@ -33,7 +33,7 @@ def fix_kafka_panel(dashboard):
                     logger.info(f"    Fixed: {old_expr} -> {target['expr']}")
                 elif old_expr == 'kafka_consumer_lag':
                     target['expr'] = 'kafka_consumer_records_lag'
-                    target['legendFormat'] = '{{consumer_group}}-{{topic}}-p{{partition}}'
+                    target['legendFormat'] = '{{client_id}}-{{topic}}-p{{partition}}'
                     logger.info(f"    Fixed: {old_expr} -> kafka_consumer_records_lag")
 
             # Update description

--- a/Scraping_project/tests/kafka/test_label_consistency.py
+++ b/Scraping_project/tests/kafka/test_label_consistency.py
@@ -1,0 +1,98 @@
+import json
+import os
+import re
+import unittest
+
+import yaml
+
+# Directories containing dashboards and rules
+DASHBOARD_DIR = 'Scraping_project/monitoring/dashboards'
+RULES_DIR = 'Scraping_project/monitoring'
+
+# Labels to check
+INCORRECT_LABELS = {'consumergroup', 'group', 'consumer_group'}
+CORRECT_LABEL = 'client_id'
+
+# Metrics to check for incorrect labels
+KAFKA_CONSUMER_METRICS = [
+    'kafka_consumer_records_lag',
+    'kafka_consumergroup_lag',
+]
+
+
+class TestKafkaLabelConsistency(unittest.TestCase):
+    def test_no_incorrect_labels_in_dashboards(self):
+        """Dashboards should not use 'consumergroup' or 'group' for consumer lag metrics."""
+        offending_panels = []
+
+        if not os.path.exists(DASHBOARD_DIR):
+            self.skipTest(f"Dashboard directory not found: {DASHBOARD_DIR}")
+
+        for filename in os.listdir(DASHBOARD_DIR):
+            if filename.endswith('.json'):
+                filepath = os.path.join(DASHBOARD_DIR, filename)
+                with open(filepath, 'r') as f:
+                    dashboard = json.load(f)
+
+                for panel in dashboard.get('panels', []):
+                    is_kafka_panel = False
+                    if 'targets' in panel:
+                        for target in panel['targets']:
+                            if 'expr' in target:
+                                for metric in KAFKA_CONSUMER_METRICS:
+                                    if metric in target['expr']:
+                                        is_kafka_panel = True
+                                        break
+                            if is_kafka_panel:
+                                break
+
+                    if is_kafka_panel:
+                        for target in panel['targets']:
+                            for key in ['expr', 'legendFormat']:
+                                if key in target:
+                                    text_to_check = target[key]
+                                    for label in INCORRECT_LABELS:
+                                        if f'{{{label}}}' in text_to_check or f'{{{label}=' in text_to_check or f',{label}=' in text_to_check:
+                                            offending_panels.append(
+                                                f"Dashboard '{dashboard.get('title', 'N/A')}' -> Panel '{panel.get('title', 'N/A')}' -> {key}"
+                                            )
+
+        self.assertEqual(
+            len(offending_panels),
+            0,
+            f"Found incorrect labels in the following dashboard panels:\n"
+            f"{'\\n'.join(offending_panels)}",
+        )
+
+    def test_no_incorrect_labels_in_rules(self):
+        """Prometheus rules should not use 'consumergroup' or 'group' for consumer lag metrics."""
+        offending_rules = []
+
+        for filename in ['alerting_rules.yml', 'recording_rules.yml']:
+            filepath = os.path.join(RULES_DIR, filename)
+            if os.path.exists(filepath):
+                with open(filepath, 'r') as f:
+                    rules = yaml.safe_load(f)
+
+                for group in rules.get('groups', []):
+                    for rule in group.get('rules', []):
+                        if 'expr' in rule:
+                            expr = rule['expr']
+                            for metric in KAFKA_CONSUMER_METRICS:
+                                if metric in expr:
+                                    for label in INCORRECT_LABELS:
+                                        if f'{{{label}=' in expr or f',{label}=' in expr:
+                                            offending_rules.append(
+                                                f"Rule '{rule.get('alert', rule.get('record', 'N/A'))}' in '{filename}'"
+                                            )
+
+        self.assertEqual(
+            len(offending_rules),
+            0,
+            f"Found incorrect labels in the following rules:\n"
+            f"{'\\n'.join(offending_rules)}",
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The Grafana dashboard for Kafka consumer lag was using a `consumer_group` label in the `legendFormat`, which was inconsistent with the `client_id` label exposed by the JMX exporter. This caused the consumer group information to be displayed incorrectly in the dashboard.

This commit fixes the issue by updating the `Scraping_project/scripts/update_dashboard.py` script to use the correct `client_id` label in the `legendFormat`. A test has also been added to verify that the generated dashboard uses the correct label, preventing future regressions.

## Summary
<!-- What does this change? Why? -->

## Checklist
- [ ] Tests pass locally (`pytest -q`)
- [ ] Lint passes (`ruff check .`)
- [ ] Updated docs / comments (if behavior changed)
- [ ] Backwards compatible (or migration noted)

## Area labels (pick)
- [ ] area/stage1
- [ ] area/stage2
- [ ] area/stage3
- [ ] area/common
- [ ] area/integration
- [ ] area/nlp
- [ ] area/ci
