### PR TITLE
feat(observability): add offline mode for Grafana alert tests

### DIFF
--- a/Scraping_project/dev-requirements.in
+++ b/Scraping_project/dev-requirements.in
@@ -8,6 +8,7 @@ pytest-cov>=4.1.0
 pytest-html>=3.1.0
 pytest-mock>=3.10.0
 pytest-timeout>=2.3.1
+requests-mock>=1.11.0
 
 # Code Quality
 black>=24.0.0

--- a/Scraping_project/docker-compose.yml
+++ b/Scraping_project/docker-compose.yml
@@ -258,6 +258,7 @@ services:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana_datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
       - ./monitoring/grafana_dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml
+      - ./monitoring/alerting:/etc/grafana/provisioning/alerting
       - ./monitoring/dashboards:/etc/grafana/provisioning/dashboards
     command: >
       bash -c "

--- a/Scraping_project/monitoring/alerting/rules.yml
+++ b/Scraping_project/monitoring/alerting/rules.yml
@@ -1,0 +1,72 @@
+# Scraping_project/monitoring/alerting/rules.yml
+apiVersion: 1
+
+groups:
+  - name: Kafka Alerts
+    # Evaluate rules every 10 seconds
+    interval: 10s
+    rules:
+      - # Alert definition
+        # UID can be used to reference this alert in other parts of Grafana
+        # If not specified, one will be generated automatically
+        uid: kafka_high_consumer_lag
+        # Title of the alert
+        title: Kafka High Consumer Lag
+        # Condition for the alert to fire
+        condition: B
+        # Alert queries
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: P846C49B2003B53C6
+            model:
+              expr: kafka_consumer_records_lag > 100
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+              type: query
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - B
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                name: Expression
+                type: __expr__
+                uid: __expr__
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              reducer: last
+              refId: B
+              type: classic_conditions
+        # How long the condition must be true for the alert to fire
+        for: 1m
+        # How often to evaluate the alert rule
+        every: 10s
+        # Labels to attach to the alert
+        labels:
+          severity: warning
+          component: kafka
+        # Annotations to attach to the alert
+        annotations:
+          summary: High Kafka consumer lag detected
+          description: "Consumer {{ $labels.client_id }} has a lag of {{ $values.A }} messages on topic {{ $labels.topic }}."

--- a/Scraping_project/tests/observability/test_alert_intervals.py
+++ b/Scraping_project/tests/observability/test_alert_intervals.py
@@ -1,0 +1,203 @@
+# Scraping_project/tests/observability/test_alert_intervals.py
+
+import unittest
+import yaml
+import requests
+import os
+import subprocess
+import time
+import re
+import requests_mock
+
+def parse_duration_to_seconds(duration_str):
+    """Converts a duration string like '15s', '1m' to seconds."""
+    if not isinstance(duration_str, str):
+        return duration_str  # Assume it's already a number
+
+    match = re.match(r"(\d+)([smhdw])", duration_str)
+    if not match:
+        raise ValueError(f"Invalid duration string: {duration_str}")
+
+    value, unit = match.groups()
+    value = int(value)
+
+    if unit == 's':
+        return value
+    elif unit == 'm':
+        return value * 60
+    elif unit == 'h':
+        return value * 3600
+    # Add other units if needed
+    return value
+
+
+class TestAlertIntervals(unittest.TestCase):
+    """
+    Validates that Grafana alert evaluation intervals are aligned with
+    the Prometheus scrape interval to prevent flapping alerts.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Starts the monitoring stack and waits for it to become healthy.
+        """
+        if os.environ.get("OBS_OFFLINE") == "1":
+            cls.min_scrape_interval = cls.get_min_scrape_interval()
+            return
+
+        cls.min_scrape_interval = cls.get_min_scrape_interval()
+
+        # Start docker-compose services
+        print("Starting monitoring stack...")
+        # Use a detached state to run in the background
+        subprocess.run(
+            "docker compose -f docker-compose.yml up -d grafana prometheus-a",
+            shell=True, check=True, cwd="Scraping_project"
+        )
+
+        # Wait for Grafana to be healthy
+        cls.wait_for_grafana()
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Stops the monitoring stack.
+        """
+        if os.environ.get("OBS_OFFLINE") == "1":
+            return
+
+        print("Stopping monitoring stack...")
+        subprocess.run(
+            "docker compose -f docker-compose.yml down",
+            shell=True, check=True, cwd="Scraping_project"
+        )
+
+    @staticmethod
+    def get_min_scrape_interval():
+        """
+        Parses prometheus.yml to find the minimum scrape interval.
+        """
+        config_path = 'Scraping_project/monitoring/prometheus.yml'
+        with open(config_path, 'r') as f:
+            config = yaml.safe_load(f)
+
+        global_interval = parse_duration_to_seconds(config.get('global', {}).get('scrape_interval', '15s'))
+
+        min_interval = global_interval
+        for job in config.get('scrape_configs', []):
+            job_interval = job.get('scrape_interval')
+            if job_interval:
+                min_interval = min(min_interval, parse_duration_to_seconds(job_interval))
+
+        return min_interval
+
+    @staticmethod
+    def wait_for_grafana():
+        """Waits for the Grafana API to become responsive."""
+        grafana_url = "http://admin:admin@localhost:3000/api/health"
+        for _ in range(30):  # Wait up to 30 seconds
+            try:
+                response = requests.get(grafana_url)
+                if response.status_code == 200:
+                    print("Grafana is up and running.")
+                    return
+            except requests.ConnectionError:
+                pass
+            time.sleep(1)
+        raise RuntimeError("Grafana did not become healthy in time.")
+
+    def _validate_rules(self, rules_response):
+        """
+        Shared logic to validate the structure and intervals of Grafana alert rules.
+        """
+        self.assertGreater(len(rules_response), 0, "No Grafana alert rule groups found.")
+
+        for group_name, rules in rules_response.items():
+            self.assertIn('rules', rules)
+            self.assertGreater(len(rules['rules']), 0, f"No rules found in group '{group_name}'")
+            for rule in rules['rules']:
+                # Handle different structures for online (API) vs offline (YAML)
+                if 'grafana_alert' in rule:  # Online mode, from API
+                    evaluate_every_str = rule['grafana_alert'].get('interval', '1m')
+                else:  # Offline mode, from rules.yml
+                    evaluate_every_str = rule.get('every', '1m')
+
+                evaluate_every = parse_duration_to_seconds(evaluate_every_str)
+                for_duration = parse_duration_to_seconds(rule['for'])
+
+                self.assertGreaterEqual(
+                    evaluate_every,
+                    self.min_scrape_interval,
+                    f"Rule '{rule.get('title', rule.get('name'))}' in group '{group_name}' has evaluateEvery ({evaluate_every}s) "
+                    f"< min_scrape_interval ({self.min_scrape_interval}s)"
+                )
+
+                self.assertEqual(
+                    for_duration % evaluate_every,
+                    0,
+                    f"Rule '{rule.get('title', rule.get('name'))}' in group '{group_name}' has 'for' duration ({for_duration}s) "
+                    f"that is not a multiple of evaluateEvery ({evaluate_every}s)"
+                )
+
+    def test_alert_intervals_are_valid_online(self):
+        """
+        Fetches Grafana alert rules and asserts their intervals are valid.
+        """
+        if os.environ.get("OBS_OFFLINE") == "1":
+            self.skipTest("Skipping online test in offline mode")
+
+        grafana_rules_url = "http://admin:admin@localhost:3000/api/ruler/grafana/api/v1/rules"
+
+        try:
+            response = requests.get(grafana_rules_url)
+            response.raise_for_status()
+            rules = response.json()
+        except requests.exceptions.RequestException as e:
+            self.fail(f"Failed to fetch Grafana rules: {e}")
+
+        self._validate_rules(rules)
+
+    @requests_mock.Mocker()
+    def test_alert_intervals_are_valid_offline(self, m):
+        """
+        Statically validates alert provisioning and rule schema.
+        """
+        if os.environ.get("OBS_OFFLINE") != "1":
+            self.skipTest("Skipping offline test in online mode")
+
+        # 1. Validate docker-compose volume mount
+        with open('Scraping_project/docker-compose.yml', 'r') as f:
+            compose_config = yaml.safe_load(f)
+
+        grafana_service = compose_config['services']['grafana']
+        volumes = grafana_service.get('volumes', [])
+        expected_mount = './monitoring/alerting:/etc/grafana/provisioning/alerting'
+        self.assertIn(expected_mount, volumes, f"Missing expected volume mount in docker-compose.yml: {expected_mount}")
+
+        # 2. Validate and mock rules.yml
+        rules_path = 'Scraping_project/monitoring/alerting/rules.yml'
+        self.assertTrue(os.path.exists(rules_path), f"Alerting rules file not found at: {rules_path}")
+
+        with open(rules_path, 'r') as f:
+            rules_content = yaml.safe_load(f)
+
+        # Create a mock response that mimics the real API structure
+        mock_api_response = {}
+        for group in rules_content.get('groups', []):
+            group_name = group.get('name')
+            if group_name:
+                mock_api_response[group_name] = {'rules': group.get('rules', [])}
+
+        m.get("http://admin:admin@localhost:3000/api/ruler/grafana/api/v1/rules", json=mock_api_response)
+
+        # 3. Reuse validation logic with mocked data
+        grafana_rules_url = "http://admin:admin@localhost:3000/api/ruler/grafana/api/v1/rules"
+        response = requests.get(grafana_rules_url)
+        self.assertEqual(response.status_code, 200)
+
+        self._validate_rules(response.json())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds an offline testing mode for Grafana alert interval validation.

This is triggered by the OBS_OFFLINE=1 environment variable and allows the test_alert_intervals.py suite to run without requiring a live Docker environment.

The key changes include:
- Adding requests-mock to mock the Grafana API.
- Modifying the test to perform static validation of docker-compose.yml and rules.yml.
- Creating a new alert rule in rules.yml for testing purposes.
- Refactoring the validation logic to handle both online and offline data structures.

## Summary
<!-- What does this change? Why? -->

## Checklist
- [ ] Tests pass locally (`pytest -q`)
- [ ] Lint passes (`ruff check .`)
- [ ] Updated docs / comments (if behavior changed)
- [ ] Backwards compatible (or migration noted)

## Area labels (pick)
- [ ] area/stage1
- [ ] area/stage2
- [ ] area/stage3
- [ ] area/common
- [ ] area/integration
- [ ] area/nlp
- [ ] area/ci
