### PR TITLE
feat: Add CI job for observability linting

### DIFF
--- a/.github/workflows/ci-observability-offline.yml
+++ b/.github/workflows/ci-observability-offline.yml
@@ -1,0 +1,39 @@
+name: CI Observability Offline
+
+on:
+  pull_request:
+    paths:
+      - 'Scraping_project/monitoring/**'
+
+jobs:
+  lint-observability:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check for promtool
+        id: promtool_check
+        run: command -v promtool &> /dev/null && echo "promtool_exists=true" >> $GITHUB_OUTPUT || echo "promtool_exists=false" >> $GITHUB_OUTPUT
+
+      - name: Run promtool to check rules
+        if: steps.promtool_check.outputs.promtool_exists == 'true'
+        uses: cpanato/promtool@v2.0.0
+        with:
+          command: check rules
+          args: Scraping_project/monitoring/alerting/*.yml
+
+      - name: Run Python Prometheus rule validation (fallback)
+        if: steps.promtool_check.outputs.promtool_exists == 'false'
+        run: python Scraping_project/tests/observability/test_prometheus_rules.py
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install PyYAML
+
+      - name: Run Grafana datasource validation
+        run: python Scraping_project/tests/observability/test_grafana_datasource.py

--- a/Scraping_project/tests/observability/test_grafana_datasource.py
+++ b/Scraping_project/tests/observability/test_grafana_datasource.py
@@ -1,0 +1,43 @@
+import yaml
+import sys
+
+def validate_grafana_datasource(file_path):
+    """
+    Validates the Grafana datasource file.
+    Ensures that all Prometheus datasources have the required fields.
+    """
+    try:
+        with open(file_path, 'r') as f:
+            data = yaml.safe_load(f)
+    except FileNotFoundError:
+        print(f"Error: Datasource file not found at {file_path}", file=sys.stderr)
+        return False
+    except yaml.YAMLError as e:
+        print(f"Error parsing YAML file: {e}", file=sys.stderr)
+        return False
+
+    if 'datasources' not in data or not isinstance(data['datasources'], list):
+        print("Error: 'datasources' key not found or is not a list in the YAML file.", file=sys.stderr)
+        return False
+
+    all_valid = True
+    for i, datasource in enumerate(data['datasources']):
+        if datasource.get('type') == 'prometheus':
+            name = datasource.get('name', f"Unnamed Prometheus datasource at index {i}")
+            if datasource.get('access') != 'proxy':
+                print(f"Validation Error in '{name}': 'access' must be 'proxy'.", file=sys.stderr)
+                all_valid = False
+            if 'url' not in datasource:
+                print(f"Validation Error in '{name}': 'url' is a required field.", file=sys.stderr)
+                all_valid = False
+
+    return all_valid
+
+if __name__ == "__main__":
+    file_to_validate = "Scraping_project/monitoring/grafana_datasource.yml"
+    if validate_grafana_datasource(file_to_validate):
+        print("Grafana datasource validation successful.")
+        sys.exit(0)
+    else:
+        print("Grafana datasource validation failed.")
+        sys.exit(1)

--- a/Scraping_project/tests/observability/test_prometheus_rules.py
+++ b/Scraping_project/tests/observability/test_prometheus_rules.py
@@ -1,0 +1,67 @@
+import yaml
+import sys
+import os
+
+def validate_prometheus_rules(directory):
+    """
+    Validates the structure of Prometheus or Grafana rule files in a directory.
+    This is a basic fallback validator for when promtool is not available.
+    """
+    all_valid = True
+    for filename in os.listdir(directory):
+        if filename.endswith(".yml") or filename.endswith(".yaml"):
+            filepath = os.path.join(directory, filename)
+            try:
+                with open(filepath, 'r') as f:
+                    data = yaml.safe_load(f)
+            except (FileNotFoundError, yaml.YAMLError) as e:
+                print(f"Error parsing {filepath}: {e}", file=sys.stderr)
+                all_valid = False
+                continue
+
+            if 'groups' not in data or not isinstance(data['groups'], list):
+                print(f"Validation Error in {filepath}: 'groups' key not found or is not a list.", file=sys.stderr)
+                all_valid = False
+                continue
+
+            for i, group in enumerate(data['groups']):
+                if 'name' not in group:
+                    print(f"Validation Error in {filepath}, group {i}: 'name' is a required field.", file=sys.stderr)
+                    all_valid = False
+                if 'rules' not in group or not isinstance(group['rules'], list):
+                    print(f"Validation Error in {filepath}, group {i}: 'rules' key not found or is not a list.", file=sys.stderr)
+                    all_valid = False
+                    continue
+                for j, rule in enumerate(group['rules']):
+                    is_prometheus_rule = ('alert' in rule or 'record' in rule) and 'expr' in rule
+                    is_grafana_rule = 'title' in rule and 'condition' in rule and 'data' in rule
+
+                    if not (is_prometheus_rule or is_grafana_rule):
+                        print(f"Validation Error in {filepath}, group {i}, rule {j}: Rule must be a valid Prometheus or Grafana alert rule.", file=sys.stderr)
+                        all_valid = False
+                        continue
+
+                    if is_grafana_rule:
+                        if not isinstance(rule.get('data'), list) or not rule.get('data'):
+                            print(f"Validation Error in {filepath}, group {i}, rule {j}: Grafana rule 'data' must be a non-empty list.", file=sys.stderr)
+                            all_valid = False
+                        else:
+                            has_expr = False
+                            for data_item in rule.get('data', []):
+                                if 'model' in data_item and 'expr' in data_item.get('model', {}):
+                                    has_expr = True
+                                    break
+                            if not has_expr:
+                                print(f"Validation Error in {filepath}, group {i}, rule {j}: No 'expr' found in any data model for Grafana rule.", file=sys.stderr)
+                                all_valid = False
+
+    return all_valid
+
+if __name__ == "__main__":
+    dir_to_validate = "Scraping_project/monitoring/alerting/"
+    if validate_prometheus_rules(dir_to_validate):
+        print("Prometheus rule validation successful.")
+        sys.exit(0)
+    else:
+        print("Prometheus rule validation failed.")
+        sys.exit(1)


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to lint observability configurations.

The new workflow, `ci-observability-offline.yml`, includes a `lint-observability` job that performs the following checks on pull requests:

- **Prometheus/Grafana Rule Validation:** It first checks for the availability of `promtool`. If found, it uses it to validate Prometheus rule files. If `promtool` is not available, it falls back to a Python script that can validate both Prometheus and Grafana alert rule formats.
- **Grafana Datasource Validation:** A new Python script validates the `grafana_datasource.yml` file, ensuring that all Prometheus datasources are correctly configured with `access: proxy` and a `url`.

This new CI job will help catch configuration errors early and ensure the stability of our monitoring and alerting setup.

## Summary
<!-- What does this change? Why? -->

## Checklist
- [ ] Tests pass locally (`pytest -q`)
- [ ] Lint passes (`ruff check .`)
- [ ] Updated docs / comments (if behavior changed)
- [ ] Backwards compatible (or migration noted)

## Area labels (pick)
- [ ] area/stage1
- [ ] area/stage2
- [ ] area/stage3
- [ ] area/common
- [ ] area/integration
- [ ] area/nlp
- [ ] area/ci
